### PR TITLE
Allow using a regex pattern for the input URL

### DIFF
--- a/src/assets/js/utils.js
+++ b/src/assets/js/utils.js
@@ -49,9 +49,9 @@ export default {
    * @param {string} tabUrl
    * @returns {boolean}
    */
-  isTabAMatch(tabUrl, configuration) {
+  isTabAMatch(tabUrlRegex, configuration) {
     const allSites = Object.values(configuration).map(each => each.url);
-    return allSites.some(each => each.includes(tabUrl));
+    return allSites.some(each => each.match(tabUrlRegex));
   },
 
   getActiveTab() {

--- a/src/components/Add.vue
+++ b/src/components/Add.vue
@@ -5,7 +5,7 @@
     <form v-on:submit.prevent="add" class="form">
       <div class="input-field">
         <label>Site url (e.g http://google.com)</label>
-        <input v-model="siteurl" type="url" />
+        <input v-model="siteurl" type="text" />
       </div>
       <button type="submit" class="btn save">Add</button>
     </form>


### PR DESCRIPTION
The json in https://github.com/femioladeji/screentime/blob/master/src/assets/js/data.js suggests that this extension supports regex url patterns (which is cool).

However, users have no way of actually entering regex pattern for domains due to URL format constraint.